### PR TITLE
Add layer to abstract out API implementation

### DIFF
--- a/YAPI/YAPI/Result.swift
+++ b/YAPI/YAPI/Result.swift
@@ -13,7 +13,7 @@ public enum Result<T, E> {
   case err(E)
 }
 
-extension Result {
+public extension Result {
   func isOk() -> Bool {
     switch self {
     case .ok(_): return true

--- a/project-alpha/project-alpha.xcodeproj/project.pbxproj
+++ b/project-alpha/project-alpha.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0846EBA41FBC156E001B0F69 /* NetworkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846EBA31FBC156E001B0F69 /* NetworkAdapter.swift */; };
+		0846EBA71FBC1CE1001B0F69 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846EBA61FBC1CE1001B0F69 /* Authenticator.swift */; };
+		0846EBAA1FBC1D23001B0F69 /* YelpV3Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846EBA91FBC1D23001B0F69 /* YelpV3Authenticator.swift */; };
+		0846EBAC1FBC1D7A001B0F69 /* YelpV3NetworkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846EBAB1FBC1D7A001B0F69 /* YelpV3NetworkAdapter.swift */; };
 		087648AF1FB8FF190058E110 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648AE1FB8FF190058E110 /* AppDelegate.swift */; };
 		087648B11FB8FF190058E110 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648B01FB8FF190058E110 /* ViewController.swift */; };
 		087648B41FB8FF190058E110 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 087648B21FB8FF190058E110 /* Main.storyboard */; };
@@ -36,6 +40,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0846EBA31FBC156E001B0F69 /* NetworkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAdapter.swift; sourceTree = "<group>"; };
+		0846EBA61FBC1CE1001B0F69 /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
+		0846EBA91FBC1D23001B0F69 /* YelpV3Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpV3Authenticator.swift; sourceTree = "<group>"; };
+		0846EBAB1FBC1D7A001B0F69 /* YelpV3NetworkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpV3NetworkAdapter.swift; sourceTree = "<group>"; };
 		087648AB1FB8FF190058E110 /* project-alpha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "project-alpha.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		087648AE1FB8FF190058E110 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		087648B01FB8FF190058E110 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -79,6 +87,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0846EBA21FBC1544001B0F69 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				0846EBA81FBC1CF9001B0F69 /* Adapters */,
+				0846EBA51FBC1CD3001B0F69 /* Authenticators */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		0846EBA51FBC1CD3001B0F69 /* Authenticators */ = {
+			isa = PBXGroup;
+			children = (
+				0846EBA61FBC1CE1001B0F69 /* Authenticator.swift */,
+				0846EBA91FBC1D23001B0F69 /* YelpV3Authenticator.swift */,
+			);
+			path = Authenticators;
+			sourceTree = "<group>";
+		};
+		0846EBA81FBC1CF9001B0F69 /* Adapters */ = {
+			isa = PBXGroup;
+			children = (
+				0846EBA31FBC156E001B0F69 /* NetworkAdapter.swift */,
+				0846EBAB1FBC1D7A001B0F69 /* YelpV3NetworkAdapter.swift */,
+			);
+			path = Adapters;
+			sourceTree = "<group>";
+		};
 		087648A21FB8FF190058E110 = {
 			isa = PBXGroup;
 			children = (
@@ -104,6 +139,7 @@
 		087648AD1FB8FF190058E110 /* project-alpha */ = {
 			isa = PBXGroup;
 			children = (
+				0846EBA21FBC1544001B0F69 /* Network */,
 				087648AE1FB8FF190058E110 /* AppDelegate.swift */,
 				087648B01FB8FF190058E110 /* ViewController.swift */,
 				087648B21FB8FF190058E110 /* Main.storyboard */,
@@ -301,6 +337,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0846EBA41FBC156E001B0F69 /* NetworkAdapter.swift in Sources */,
+				0846EBAA1FBC1D23001B0F69 /* YelpV3Authenticator.swift in Sources */,
+				0846EBA71FBC1CE1001B0F69 /* Authenticator.swift in Sources */,
+				0846EBAC1FBC1D7A001B0F69 /* YelpV3NetworkAdapter.swift in Sources */,
 				087648B11FB8FF190058E110 /* ViewController.swift in Sources */,
 				087648AF1FB8FF190058E110 /* AppDelegate.swift in Sources */,
 			);

--- a/project-alpha/project-alpha/Network/Adapters/NetworkAdapter.swift
+++ b/project-alpha/project-alpha/Network/Adapters/NetworkAdapter.swift
@@ -1,0 +1,22 @@
+//
+//  NetworkAdapter.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 11/14/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+
+struct SearchParameters {
+  var distance: Int
+}
+
+protocol BusinessModel {
+  var name: String { get }
+}
+
+protocol NetworkAdapter {
+  func makeSearchRequest(with params: SearchParameters, completionHandler: @escaping (Result<[BusinessModel], Error>) -> Void)
+}

--- a/project-alpha/project-alpha/Network/Adapters/YelpV3NetworkAdapter.swift
+++ b/project-alpha/project-alpha/Network/Adapters/YelpV3NetworkAdapter.swift
@@ -1,0 +1,26 @@
+//
+//  YelpV3NetworkAdapter.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 11/14/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+
+extension YelpV3Business: BusinessModel {}
+
+final class YelpV3NetworkAdapter: NetworkAdapter {
+  func makeSearchRequest(with params: SearchParameters, completionHandler: @escaping (Result<[BusinessModel], Error>) -> Void) {
+    let radius = YelpV3SearchParameters.Radius(params.distance)
+    let location = YelpV3LocationParameter(location: "Portland, OR")
+    let yelpSearchParams = YelpV3SearchParameters(location: location, radius: radius)
+    let request = YelpAPIFactory.V3.makeSearchRequest(with: yelpSearchParams)
+    
+    request.send { result in
+      //                                            \/ This is really dumb...
+      completionHandler(result.map { $0.businesses }.mapErr { $0 })
+    }
+  }
+}

--- a/project-alpha/project-alpha/Network/Authenticators/Authenticator.swift
+++ b/project-alpha/project-alpha/Network/Authenticators/Authenticator.swift
@@ -1,0 +1,16 @@
+//
+//  Authenticator.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 11/14/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+
+protocol Authenticator {
+  associatedtype TokenType
+  
+  static func authenticate(with token: TokenType, completionHandler: @escaping (Result<NetworkAdapter, Error>) -> Void)
+}

--- a/project-alpha/project-alpha/Network/Authenticators/YelpV3Authenticator.swift
+++ b/project-alpha/project-alpha/Network/Authenticators/YelpV3Authenticator.swift
@@ -1,0 +1,33 @@
+//
+//  YelpV3Authenticator.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 11/14/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+
+struct YelpV3AuthenticationToken {
+  let appId: String
+  let clientSecret: String
+}
+
+final class YelpV3Authenticator: Authenticator {
+  typealias TokenType = YelpV3AuthenticationToken
+  
+  class func authenticate(with token: YelpV3AuthenticationToken, completionHandler: @escaping (Result<NetworkAdapter, Error>) -> Void) {
+    YelpAPIFactory.V3.authenticate(appId: token.appId, clientSecret: token.clientSecret) { error in
+      let result: Result<NetworkAdapter, Error>
+      if let error = error {
+        result = .err(error)
+      }
+      else {
+        result = .ok(YelpV3NetworkAdapter())
+      }
+      
+      completionHandler(result)
+    }
+  }
+}

--- a/project-alpha/project-alpha/ViewController.swift
+++ b/project-alpha/project-alpha/ViewController.swift
@@ -34,13 +34,24 @@ class ViewController: UIViewController {
         assertionFailure("Unable to retrieve appId or clientSecret from file")
         return
     }
+    let authToken = YelpV3AuthenticationToken(appId: appId, clientSecret: clientSecret)
     
-    YelpAPIFactory.V3.authenticate(appId: appId, clientSecret: clientSecret) { error in
-      if let error = error {
-        print("\(error)")
+    YelpV3Authenticator.authenticate(with: authToken) { result in
+      guard case .ok(let networkAdapter) = result else {
+        print("Error authenticating: \(result.unwrapErr())")
+        return
       }
-      else {
-        print("Authenticated")
+      
+      let params = SearchParameters(distance: 1000)
+      networkAdapter.makeSearchRequest(with: params) { result in
+        guard case .ok(let businesses) = result else {
+          print("Error in response: \(result.unwrapErr())")
+          return
+        }
+        
+        for business in businesses {
+          print(business.name)
+        }
       }
     }
   }


### PR DESCRIPTION
This adds a framework for an interface that can be used in order to swap
out different backend API implementations. The client code shouldn't
have to worry about what API is being talked to as long as it works
through the `NetworkAdapter` interface. The only time the client needs
to be aware of what it's going to talk to is at the beginning of the app
when it needs to authenticate itself to the API. Unfortunately this step
could not be cleanly abstracted away from the client as each API has
potentially different authentication mechanisms. Once authentication is
complete we are given a `NetworkAdapter` object that we can use
throughout the rest of the app. So all customization comes at
authentication time, after that the API integration becomes opaque to
the client.

I tested out a few different ideas on creating this abstraction and this
solution seemed to me to be the simplest and easiest to implement. Some
of my other attempts included modifying the `Request` and `Response`
protocols at the `YAPI` layer to make them more customizable to support
different API integrations, but this very quickly made the interface
into the `YAPI` layer unweildy and very confusing.

@munchur Let me know if you've got any questions or concerns about this implementation. This is mainly just a sample to make sure it makes sense to do it this way. There is still some extra stuff that needs to be fleshed out like what we need in our `BusinessModel` protocol in order to populate the UI.