### PR TITLE
 Defer completion handler on simultaneous image loads

### DIFF
--- a/YAPI/YAPI.xcodeproj/project.pbxproj
+++ b/YAPI/YAPI.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		0858705E1FD0FD42000F973A /* Threading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705D1FD0FD42000F973A /* Threading.swift */; };
 		085870601FD0FD84000F973A /* ConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705F1FD0FD84000F973A /* ConditionTests.swift */; };
 		085870621FD325FF000F973A /* MockObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085870611FD325FF000F973A /* MockObjects.swift */; };
+		085870641FD3344B000F973A /* YAPIXCNetworkTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085870631FD3344B000F973A /* YAPIXCNetworkTestCase.swift */; };
 		087490321FB7C3CD0072E539 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490311FB7C3CD0072E539 /* Result.swift */; };
 		087490341FB811F90072E539 /* YelpV3SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490331FB811F90072E539 /* YelpV3SearchResponse.swift */; };
 		087490361FB813A50072E539 /* YelpBusiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490351FB813A50072E539 /* YelpBusiness.swift */; };
@@ -162,6 +163,7 @@
 		0858705D1FD0FD42000F973A /* Threading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Threading.swift; path = Shared/Utilities/Threading.swift; sourceTree = "<group>"; };
 		0858705F1FD0FD84000F973A /* ConditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConditionTests.swift; path = Misc/ConditionTests.swift; sourceTree = "<group>"; };
 		085870611FD325FF000F973A /* MockObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockObjects.swift; path = Mocks/MockObjects.swift; sourceTree = "<group>"; };
+		085870631FD3344B000F973A /* YAPIXCNetworkTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YAPIXCNetworkTestCase.swift; path = TestHelpers/YAPIXCNetworkTestCase.swift; sourceTree = "<group>"; };
 		087490311FB7C3CD0072E539 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		087490331FB811F90072E539 /* YelpV3SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpV3SearchResponse.swift; path = V3/YelpV3SearchResponse.swift; sourceTree = "<group>"; };
 		087490351FB813A50072E539 /* YelpBusiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpBusiness.swift; path = V3/Models/YelpBusiness.swift; sourceTree = "<group>"; };
@@ -691,6 +693,7 @@
 				08CD2CF61D78120D00DBFA24 /* AssertOverride.swift */,
 				08CD2CFE1D7B436700DBFA24 /* YAPIXCTestCase.swift */,
 				0874903E1FB828B80072E539 /* Utilities.swift */,
+				085870631FD3344B000F973A /* YAPIXCNetworkTestCase.swift */,
 			);
 			name = TestHelpers;
 			sourceTree = "<group>";
@@ -993,6 +996,7 @@
 				08CD2CE51D78073100DBFA24 /* YelpV2SearchResponseTests.swift in Sources */,
 				08025B321DA31140001636DB /* YelpV3TokenRequestTests.swift in Sources */,
 				08CD2CFF1D7B436700DBFA24 /* YAPIXCTestCase.swift in Sources */,
+				085870641FD3344B000F973A /* YAPIXCNetworkTestCase.swift in Sources */,
 				08CD2CE81D78073100DBFA24 /* HTTPClientTests.swift in Sources */,
 				08219C821FC11B5700EA034F /* GoogleEstablishmentTests.swift in Sources */,
 				08CD2CE61D78073100DBFA24 /* YelpDataModelTests.swift in Sources */,

--- a/YAPI/YAPI.xcodeproj/project.pbxproj
+++ b/YAPI/YAPI.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		0858705C1FD0EC5A000F973A /* UIImage+YAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705B1FD0EC5A000F973A /* UIImage+YAPI.swift */; };
 		0858705E1FD0FD42000F973A /* Threading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705D1FD0FD42000F973A /* Threading.swift */; };
 		085870601FD0FD84000F973A /* ConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705F1FD0FD84000F973A /* ConditionTests.swift */; };
+		085870621FD325FF000F973A /* MockObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085870611FD325FF000F973A /* MockObjects.swift */; };
 		087490321FB7C3CD0072E539 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490311FB7C3CD0072E539 /* Result.swift */; };
 		087490341FB811F90072E539 /* YelpV3SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490331FB811F90072E539 /* YelpV3SearchResponse.swift */; };
 		087490361FB813A50072E539 /* YelpBusiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490351FB813A50072E539 /* YelpBusiness.swift */; };
@@ -160,6 +161,7 @@
 		0858705B1FD0EC5A000F973A /* UIImage+YAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIImage+YAPI.swift"; path = "Shared/Extensions/UIImage+YAPI.swift"; sourceTree = "<group>"; };
 		0858705D1FD0FD42000F973A /* Threading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Threading.swift; path = Shared/Utilities/Threading.swift; sourceTree = "<group>"; };
 		0858705F1FD0FD84000F973A /* ConditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConditionTests.swift; path = Misc/ConditionTests.swift; sourceTree = "<group>"; };
+		085870611FD325FF000F973A /* MockObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockObjects.swift; path = Mocks/MockObjects.swift; sourceTree = "<group>"; };
 		087490311FB7C3CD0072E539 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		087490331FB811F90072E539 /* YelpV3SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpV3SearchResponse.swift; path = V3/YelpV3SearchResponse.swift; sourceTree = "<group>"; };
 		087490351FB813A50072E539 /* YelpBusiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpBusiness.swift; path = V3/Models/YelpBusiness.swift; sourceTree = "<group>"; };
@@ -383,7 +385,7 @@
 				089CC6AC1D9AE3590018F1D1 /* V2 */,
 				089CC6AD1D9AE35D0018F1D1 /* V3 */,
 				08CD2CF51D7811F800DBFA24 /* TestHelpers */,
-				08CD2CE91D78074A00DBFA24 /* NetworkMocks */,
+				08CD2CE91D78074A00DBFA24 /* Mocks */,
 				083C5E421D77280A00132923 /* Info.plist */,
 				08CD2D021D7B4E1600DBFA24 /* YelpAuthenticationTests.swift */,
 			);
@@ -673,13 +675,14 @@
 			name = Factory;
 			sourceTree = "<group>";
 		};
-		08CD2CE91D78074A00DBFA24 /* NetworkMocks */ = {
+		08CD2CE91D78074A00DBFA24 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
 				08CD2CDE1D78073100DBFA24 /* ResponseInjections.swift */,
 				08CD2CD81D78073100DBFA24 /* NetworkMockObjects.swift */,
+				085870611FD325FF000F973A /* MockObjects.swift */,
 			);
-			name = NetworkMocks;
+			name = Mocks;
 			sourceTree = "<group>";
 		};
 		08CD2CF51D7811F800DBFA24 /* TestHelpers */ = {
@@ -986,6 +989,7 @@
 				08A0FA971D85FA8900FEB43C /* YelpActionlinkParametersTests.swift in Sources */,
 				08A0FAA71D86303C00FEB43C /* YelpRequestTestCase.swift in Sources */,
 				08CD2CE11D78073100DBFA24 /* NetworkMockObjects.swift in Sources */,
+				085870621FD325FF000F973A /* MockObjects.swift in Sources */,
 				08CD2CE51D78073100DBFA24 /* YelpV2SearchResponseTests.swift in Sources */,
 				08025B321DA31140001636DB /* YelpV3TokenRequestTests.swift in Sources */,
 				08CD2CFF1D7B436700DBFA24 /* YAPIXCTestCase.swift in Sources */,

--- a/YAPI/YAPI.xcodeproj/project.pbxproj
+++ b/YAPI/YAPI.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		083C5E721D772AC200132923 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C5E5E1D772AC200132923 /* Request.swift */; };
 		083C5E751D772AC200132923 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083C5E611D772AC200132923 /* Errors.swift */; };
 		085870501FC969C9000F973A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 089CC6A71D9ADAEA0018F1D1 /* Foundation.framework */; };
+		0858705C1FD0EC5A000F973A /* UIImage+YAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705B1FD0EC5A000F973A /* UIImage+YAPI.swift */; };
+		0858705E1FD0FD42000F973A /* Threading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705D1FD0FD42000F973A /* Threading.swift */; };
+		085870601FD0FD84000F973A /* ConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858705F1FD0FD84000F973A /* ConditionTests.swift */; };
 		087490321FB7C3CD0072E539 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490311FB7C3CD0072E539 /* Result.swift */; };
 		087490341FB811F90072E539 /* YelpV3SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490331FB811F90072E539 /* YelpV3SearchResponse.swift */; };
 		087490361FB813A50072E539 /* YelpBusiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087490351FB813A50072E539 /* YelpBusiness.swift */; };
@@ -154,6 +157,9 @@
 		083C5E5D1D772AC200132923 /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		083C5E5E1D772AC200132923 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		083C5E611D772AC200132923 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		0858705B1FD0EC5A000F973A /* UIImage+YAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIImage+YAPI.swift"; path = "Shared/Extensions/UIImage+YAPI.swift"; sourceTree = "<group>"; };
+		0858705D1FD0FD42000F973A /* Threading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Threading.swift; path = Shared/Utilities/Threading.swift; sourceTree = "<group>"; };
+		0858705F1FD0FD84000F973A /* ConditionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConditionTests.swift; path = Misc/ConditionTests.swift; sourceTree = "<group>"; };
 		087490311FB7C3CD0072E539 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		087490331FB811F90072E539 /* YelpV3SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpV3SearchResponse.swift; path = V3/YelpV3SearchResponse.swift; sourceTree = "<group>"; };
 		087490351FB813A50072E539 /* YelpBusiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YelpBusiness.swift; path = V3/Models/YelpBusiness.swift; sourceTree = "<group>"; };
@@ -404,6 +410,7 @@
 				08E0F6801FBD64BC004C3D24 /* Logging.swift */,
 				08E0F6921FBDB706004C3D24 /* JSONPrettyPrint.swift */,
 				0881940A1FC0E7D10090E67C /* Cache.swift */,
+				0858705D1FD0FD42000F973A /* Threading.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -432,6 +439,7 @@
 				08CD2CD71D78073100DBFA24 /* ImageReferenceTests.swift */,
 				087490411FB82D880072E539 /* ResultTests.swift */,
 				088194081FC0DB260090E67C /* CacheTests.swift */,
+				0858705F1FD0FD84000F973A /* ConditionTests.swift */,
 			);
 			name = Miscelaneous;
 			sourceTree = "<group>";
@@ -612,6 +620,7 @@
 			children = (
 				08A0FA9D1D861DE000FEB43C /* String+YAPI.swift */,
 				08A0FA9F1D86232A00FEB43C /* Dictionary+YAPI.swift */,
+				0858705B1FD0EC5A000F973A /* UIImage+YAPI.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -941,6 +950,7 @@
 				08CD2CFD1D7B3F7700DBFA24 /* YelpAuthentication.swift in Sources */,
 				087490321FB7C3CD0072E539 /* Result.swift in Sources */,
 				089CC6D41D9AE84C0018F1D1 /* V2_YelpBusinessDataModels.swift in Sources */,
+				0858705C1FD0EC5A000F973A /* UIImage+YAPI.swift in Sources */,
 				089CC6C21D9AE81B0018F1D1 /* V2_YelpPhoneSearchRequest.swift in Sources */,
 				089CC6C31D9AE81B0018F1D1 /* V2_YelpBusinessRequest.swift in Sources */,
 				08E0F6961FBEB592004C3D24 /* GoogleEstablishment.swift in Sources */,
@@ -950,6 +960,7 @@
 				0874903B1FB81FDE0072E539 /* Coordinate.swift in Sources */,
 				089CC6B21D9AE6500018F1D1 /* Response.swift in Sources */,
 				08025B2D1DA30E2B001636DB /* YelpV3Response.swift in Sources */,
+				0858705E1FD0FD42000F973A /* Threading.swift in Sources */,
 				08025B381DA31847001636DB /* YelpV3SearchRequest.swift in Sources */,
 				08025B3A1DA31972001636DB /* YelpV3SearchParameters.swift in Sources */,
 				089CC6CE1D9AE8360018F1D1 /* V2_YelpPhoneSearchParameters.swift in Sources */,
@@ -991,6 +1002,7 @@
 				08FB75CF1FC0F86200F986D9 /* APIFactoryTests.swift in Sources */,
 				08CD2CE71D78073100DBFA24 /* ResponseInjections.swift in Sources */,
 				08CD2CE41D78073100DBFA24 /* YelpV2SearchRequestTests.swift in Sources */,
+				085870601FD0FD84000F973A /* ConditionTests.swift in Sources */,
 				08025B361DA31620001636DB /* YelpV3TokenParametersTests.swift in Sources */,
 				08A0FAA51D862FAE00FEB43C /* YelpV2BusinessRequestTests.swift in Sources */,
 				08A0FA991D85FC6D00FEB43C /* YelpSearchParametersTests.swift in Sources */,

--- a/YAPI/YAPI/Shared/Extensions/UIImage+YAPI.swift
+++ b/YAPI/YAPI/Shared/Extensions/UIImage+YAPI.swift
@@ -1,0 +1,18 @@
+//
+//  UIImage+YAPI.swift
+//  YAPI
+//
+//  Created by Daniel Seitz on 11/30/17.
+//  Copyright © 2017 Daniel Seitz. All rights reserved.
+//
+
+import Foundation
+
+extension UIImage {
+  func copy(withScale scale: CGFloat = 1.0) -> UIImage? {
+    guard let cgImage = self.cgImage?.copy() else {
+      return nil
+    }
+    return UIImage(cgImage: cgImage, scale: scale, orientation: self.imageOrientation)
+  }
+}

--- a/YAPI/YAPI/Shared/Utilities/Cache.swift
+++ b/YAPI/YAPI/Shared/Utilities/Cache.swift
@@ -11,25 +11,25 @@ import Foundation
 // Used to uniquely identify cacheAccessQueues
 private var id: Int = 0
 
-internal protocol Cacheable: class {
+public protocol Cacheable: class {
   var isCacheable: Bool { get }
   var cacheKey: CacheKey { get }
 }
 
-internal struct CacheKey {
+public struct CacheKey {
   fileprivate let key: String
   
-  init(_ key: String) {
+  public init(_ key: String) {
     self.key = key
   }
 }
 
-final class Cache<Stored: Cacheable> {
+final public class Cache<Stored: Cacheable> {
   private var internalCache = [String: Stored]()
   private let cacheAccessQueue: DispatchQueue
   let identifier: String
   
-  init(identifier: String) {
+  public init(identifier: String) {
     self.identifier = identifier
     self.cacheAccessQueue = DispatchQueue(label: "com.yapi.cache-access.\(identifier)-\(id)", attributes: .concurrent)
     id += 1
@@ -38,7 +38,7 @@ final class Cache<Stored: Cacheable> {
   // TODO (dseitz): Uh... I think statics in Swift are automatically synchronized across
   // threads... So I don't think we need any of these synchronization operations... Let's
   // do some research
-  subscript(key: CacheKey) -> Stored? {
+  public subscript(key: CacheKey) -> Stored? {
     get {
       var imageReference: Stored? = nil
       self.readLock() {
@@ -51,7 +51,7 @@ final class Cache<Stored: Cacheable> {
   /**
    Flush all items from the cache
    */
-  func flush() {
+  public func flush() {
     log(.info, for: .caching, message: "Cache (\(identifier)) was flushed")
     self.writeLock() {
       self.internalCache.removeAll()
@@ -65,7 +65,7 @@ final class Cache<Stored: Cacheable> {
    
    - Returns: true if the object is in the cache, false if it is not
    */
-  func contains(_ object: Stored) -> Bool {
+  public func contains(_ object: Stored) -> Bool {
     return self[object.cacheKey] != nil
   }
   
@@ -77,7 +77,7 @@ final class Cache<Stored: Cacheable> {
    - Returns: true if the object was successfully inserted, false otherwise
    */
   @discardableResult
-  func insert(_ object: Stored) -> Bool {
+  public func insert(_ object: Stored) -> Bool {
     guard object.isCacheable else { return false }
     
     let alreadyCached = internalCache[object.cacheKey.key]

--- a/YAPI/YAPI/Shared/Utilities/Threading.swift
+++ b/YAPI/YAPI/Shared/Utilities/Threading.swift
@@ -12,6 +12,7 @@ class Condition<Signaled> {
   private let condition: NSCondition = NSCondition()
   private var value: Signaled?
   
+  @discardableResult
   func wait() -> Signaled {
     condition.lock()
     defer {

--- a/YAPI/YAPI/Shared/Utilities/Threading.swift
+++ b/YAPI/YAPI/Shared/Utilities/Threading.swift
@@ -1,0 +1,40 @@
+//
+//  Threading.swift
+//  YAPI
+//
+//  Created by Daniel Seitz on 11/30/17.
+//  Copyright © 2017 Daniel Seitz. All rights reserved.
+//
+
+import Foundation
+
+class Condition<Signaled> {
+  private let condition: NSCondition = NSCondition()
+  private var value: Signaled?
+  
+  func wait() -> Signaled {
+    condition.lock()
+    defer {
+      condition.unlock()
+    }
+    
+    while true {
+      guard let value = value else {
+        condition.wait()
+        continue
+      }
+      
+      return value
+    }
+  }
+  
+  func broadcast(value: Signaled) {
+    condition.lock()
+    defer {
+      condition.unlock()
+    }
+    
+    self.value = value
+    condition.broadcast()
+  }
+}

--- a/YAPI/YAPITests/ImageReferenceTests.swift
+++ b/YAPI/YAPITests/ImageReferenceTests.swift
@@ -9,23 +9,11 @@
 import XCTest
 @testable import YAPI
 
-class ImageReferenceTests: YAPIXCTestCase {
-  
-  var session: HTTPClient!
-  let mockSession = MockURLSession()
-  
-  override func setUp() {
-    super.setUp()
-    
-    session = HTTPClient(session: mockSession)
-  }
+class ImageReferenceTests: YAPIXCNetworkTestCase {
+  let mockCache = Cache<ImageReference>(identifier: "MockCache")
   
   override func tearDown() {
-    ImageReference.globalCache.flush()
-    
-    mockSession.nextData = nil
-    mockSession.nextError = nil
-    mockSession.asyncAfter = nil
+    mockCache.flush()
     
     super.tearDown()
   }
@@ -38,12 +26,15 @@ class ImageReferenceTests: YAPIXCTestCase {
   
   func test_LoadImage_WhileLoadIsInFlight_DefersLoadForImage() {
     mockSession.asyncAfter = .milliseconds(100)
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+
     var image: UIImage? = nil
     var image2: UIImage? = nil
+
     let expect = expectation(description: "The image load finished")
     let expect2 = expectation(description: "The second image load finished")
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
     
     imageReference.load { result in
       XCTAssert(result.isOk())
@@ -68,7 +59,7 @@ class ImageReferenceTests: YAPIXCTestCase {
   
   func test_LoadImage_WhileLoadIsInFlight_MultipleLoads_DefersLoadsForImage() {
     mockSession.asyncAfter = .milliseconds(100)
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
 
     var image: UIImage? = nil
     var image2: UIImage? = nil
@@ -80,7 +71,7 @@ class ImageReferenceTests: YAPIXCTestCase {
     let expect3 = expectation(description: "The third image load finished")
     let expect4 = expectation(description: "The fourth image load finished")
     
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
     
     imageReference.load { result in
       XCTAssert(result.isOk())
@@ -121,12 +112,13 @@ class ImageReferenceTests: YAPIXCTestCase {
   
   func test_LoadImage_WhileLoadIsInFlight_ErrorInLoad_ReturnsError() {
     mockSession.asyncAfter = .milliseconds(100)
+    mockSession.nextError = Mock.error
     var resultError: ImageLoadError? = nil
     
     let expect = expectation(description: "The image load finished")
     let expect2 = expectation(description: "The second image load finished")
     
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
     
     imageReference.load { result in
       XCTAssert(result.isErr())
@@ -147,27 +139,32 @@ class ImageReferenceTests: YAPIXCTestCase {
   }
   
   func test_LoadImage_LoadsAnImageFromValidData() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
-    imageReference.load() { (result) -> Void in
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+    imageReference.load() { result in
       XCTAssert(result.isOk())
     }
   }
   
   func test_LoadImage_LoadsAnImageFromValidData_CachesTheImage() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
-    imageReference.load() { (result) -> Void in }
-    let imageReference2 = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
-    imageReference2.load() { (result) -> Void in }
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+    
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+    let imageReference2 = ImageReference(from: Mock.url, using: mockCache, session: session)
+
+    imageReference.load() { _ in }
+    imageReference2.load() { _ in }
+
     XCTAssertNotNil(imageReference.cachedImage)
     XCTAssertNotNil(imageReference2.cachedImage)
   }
   
   func test_LoadImage_LoadsAnImageFromInvalidData_GivesAnError() {
     mockSession.nextData = Data()
-    let imageReference = ImageReference(from: URL(fileURLWithPath: ""), session: session)
-    imageReference.load() { (result) -> Void in
+
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+
+    imageReference.load() { result in
       XCTAssert(result.isErr())
       
       guard case .invalidData = result.unwrapErr() else {
@@ -177,21 +174,23 @@ class ImageReferenceTests: YAPIXCTestCase {
   }
   
   func test_LoadImage_WhereRequestErrors_GivesTheError() {
-    let mockError = NSError(domain: "error", code: 0, userInfo: nil)
-    mockSession.nextError = mockError
-    let imageReference = ImageReference(from: URL(fileURLWithPath: ""), session: session)
-    imageReference.load() { (result) -> Void in
+    mockSession.nextError = Mock.error
+
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+
+    imageReference.load() { result in
       XCTAssert(result.isErr())
       
-      guard case .requestError(mockError) = result.unwrapErr() else {
+      guard case .requestError = result.unwrapErr() else {
         return XCTFail("Error was wrong type")
       }
     }
   }
   
   func test_LoadImage_RecievesNoData_GivesAnError() {
-    let imageReference = ImageReference(from: URL(fileURLWithPath: ""), session: session)
-    imageReference.load() { (result) -> Void in
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+
+    imageReference.load() { result in
       XCTAssert(result.isErr())
       
       guard case .noDataReceived = result.unwrapErr() else {
@@ -201,9 +200,10 @@ class ImageReferenceTests: YAPIXCTestCase {
   }
   
   func test_LoadImage_WithDifferentImageReferencesToSameURL_GivesCachedImage() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
-    let imageReference2 = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
+    let imageReference2 = ImageReference(from: Mock.url, using: mockCache, session: session)
     
     imageReference.load() { (result) -> Void in
       imageReference2.load() { (result2) -> Void in
@@ -217,46 +217,42 @@ class ImageReferenceTests: YAPIXCTestCase {
         let imageData2 = UIImagePNGRepresentation(image2)!
         let cachedImageData = UIImagePNGRepresentation(imageReference.cachedImage!)!
         let cachedImageData2 = UIImagePNGRepresentation(imageReference2.cachedImage!)!
-        
-        XCTAssert(imageReference.cachedImage !== image)
-        XCTAssert(imageReference.cachedImage !== image2)
+
         XCTAssert(cachedImageData == imageData)
         XCTAssert(cachedImageData == imageData2)
-        XCTAssert(imageReference2.cachedImage !== image)
-        XCTAssert(imageReference2.cachedImage !== image2)
         XCTAssert(cachedImageData2 == imageData)
         XCTAssert(cachedImageData2 == imageData2)
-        XCTAssert(image !== image2)
         XCTAssert(imageData == imageData2)
-        
-        XCTAssert(imageReference.cachedImage !== imageReference2.cachedImage)
       }
     }
   }
   
-  func test_LoadImage_StoresImagesInGlobalCache() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
+  func test_LoadImage_StoresImagesInCache() {
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
     let url = URL(string: "http://s3-media3.fl.yelpcdn.com/asdf.jpg")!
     let url2 = URL(string: "http://s3-media3.fl.yelpcdn.com/qwer.jpg")!
-    let imageReference = ImageReference(from: url, session: session)
-    let imageReference2 = ImageReference(from: url2, session: session)
+    let imageReference = ImageReference(from: url, using: mockCache, session: session)
+    let imageReference2 = ImageReference(from: url2, using: mockCache, session: session)
     
-    imageReference.load() { (result) -> Void in
-      imageReference2.load() { (result2) -> Void in
+    XCTAssertFalse(mockCache.contains(imageReference))
+    XCTAssertFalse(mockCache.contains(imageReference2))
+
+    imageReference.load() { result in
+      imageReference2.load() { result2 in
         XCTAssert(result.isOk())
         XCTAssert(result2.isOk())
         
-        XCTAssert(ImageReference.globalCache.contains(imageReference) == true)
-        XCTAssert(ImageReference.globalCache.contains(imageReference2) == true)
+        XCTAssertTrue(self.mockCache.contains(imageReference))
+        XCTAssertTrue(self.mockCache.contains(imageReference2))
       }
     }
   }
   
   func test_CachedImageProperty_ReturnsCopy() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
     
-    imageReference.load() { (result) -> Void in
+    imageReference.load() { result in
       let cachedImage = imageReference.cachedImage
       
       XCTAssertNotNil(cachedImage)
@@ -273,10 +269,10 @@ class ImageReferenceTests: YAPIXCTestCase {
   }
   
   func test_LoadImageWithScale_ScalesTheImage() {
-    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage, options: .ignoreUnknownCharacters)
-    let imageReference = ImageReference(from: URL(string: "http://s3-media3.fl.yelpcdn.com/bphoto/nQK-6_vZMt5n88zsAS94ew/ms.jpg")!, session: session)
+    mockSession.nextData = Data(base64Encoded: ResponseInjections.yelpValidImage)
+    let imageReference = ImageReference(from: Mock.url, using: mockCache, session: session)
     
-    imageReference.load(withScale: 0.5) { (result) -> Void in
+    imageReference.load(withScale: 0.5) { result in
       XCTAssert(result.isOk())
       
       let image = result.unwrap()
@@ -284,7 +280,7 @@ class ImageReferenceTests: YAPIXCTestCase {
       XCTAssert(image.scale == 0.5)
     }
     
-    imageReference.load(withScale: 1.5) { (result) -> Void in
+    imageReference.load(withScale: 1.5) { result in
       XCTAssert(result.isOk())
       
       let image = result.unwrap()
@@ -294,7 +290,7 @@ class ImageReferenceTests: YAPIXCTestCase {
     
     XCTAssert(imageReference.cachedImage?.scale == 1.0)
   }
-  
+ 
   func test_Subclass_OverridesCachedImage_LoadsFromOverriddenProperty() {
     class MockImageReference: ImageReference {
       let expectedImage: UIImage
@@ -303,14 +299,16 @@ class ImageReferenceTests: YAPIXCTestCase {
         return expectedImage
       }
       
-      init(expectedImage: UIImage, session: HTTPClient) {
+      init(expectedImage: UIImage,
+           using cache: Cache<ImageReference>,
+           session: HTTPClient) {
         self.expectedImage = expectedImage
-        super.init(from: Mock.url, session: session)
+        super.init(from: Mock.url, using: cache, session: session)
       }
     }
     
     let expectedImage = UIImage(data: Data(base64Encoded: ResponseInjections.yelpValidImage)!)!
-    let mockImageReference = MockImageReference(expectedImage: expectedImage, session: session)
+    let mockImageReference = MockImageReference(expectedImage: expectedImage, using: mockCache, session: session)
     
     let expectedImageData = UIImagePNGRepresentation(expectedImage)!
     let cachedImageData = UIImagePNGRepresentation(mockImageReference.cachedImage!)!
@@ -323,7 +321,6 @@ class ImageReferenceTests: YAPIXCTestCase {
       let loadedImageData = UIImagePNGRepresentation(result.unwrap())!
       
       XCTAssertEqual(expectedImageData, loadedImageData)
-    }
-    
+    }    
   }
 }

--- a/YAPI/YAPITests/Misc/ConditionTests.swift
+++ b/YAPI/YAPITests/Misc/ConditionTests.swift
@@ -1,0 +1,33 @@
+//
+//  ConditionTests.swift
+//  YAPITests
+//
+//  Created by Daniel Seitz on 11/30/17.
+//  Copyright © 2017 Daniel Seitz. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import YAPI
+
+class ConditionTests: YAPIXCTestCase {
+  func test_Condition_WaitReturnsBroadcastedValue() {
+    let condition = Condition<Int>()
+    let expect = expectation(description: "Thread was awoken")
+    let expectedValue = 5
+    var actualValue: Int? = nil
+    
+    DispatchQueue.main.async {
+      actualValue = condition.wait()
+      expect.fulfill()
+    }
+    
+    condition.broadcast(value: 5)
+    
+    waitForExpectations(timeout: 1.0) { error in
+      XCTAssertNil(error)
+      XCTAssertEqual(actualValue, expectedValue)
+    }
+  }
+}

--- a/YAPI/YAPITests/Misc/ConditionTests.swift
+++ b/YAPI/YAPITests/Misc/ConditionTests.swift
@@ -12,22 +12,54 @@ import XCTest
 @testable import YAPI
 
 class ConditionTests: YAPIXCTestCase {
-  func test_Condition_WaitReturnsBroadcastedValue() {
+  func test_Condition_Wait_ReturnsBroadcastedValue() {
     let condition = Condition<Int>()
     let expect = expectation(description: "Thread was awoken")
     let expectedValue = 5
     var actualValue: Int? = nil
     
-    DispatchQueue.main.async {
+    DispatchQueue.global().async {
       actualValue = condition.wait()
       expect.fulfill()
     }
     
-    condition.broadcast(value: 5)
+    DispatchQueue.global().async {
+      condition.broadcast(value: 5)
+    }
     
     waitForExpectations(timeout: 1.0) { error in
       XCTAssertNil(error)
       XCTAssertEqual(actualValue, expectedValue)
+    }
+  }
+  
+  func test_Condition_Broadcast_WakesAllWaitingThreads() {
+    let condition = Condition<()>()
+    let expect = expectation(description: "Thread was awoken")
+    let expect2 = expectation(description: "Second thread was awoken")
+    let expect3 = expectation(description: "Third thread was awoken")
+    
+    DispatchQueue.global().async {
+      condition.wait()
+      expect.fulfill()
+    }
+    
+    DispatchQueue.global().async {
+      condition.wait()
+      expect2.fulfill()
+    }
+    
+    DispatchQueue.global().async {
+      condition.wait()
+      expect3.fulfill()
+    }
+    
+    DispatchQueue.global().async {
+      condition.broadcast(value: ())
+    }
+    
+    waitForExpectations(timeout: 1.0) { error in
+      XCTAssertNil(error)
     }
   }
 }

--- a/YAPI/YAPITests/Mocks/MockObjects.swift
+++ b/YAPI/YAPITests/Mocks/MockObjects.swift
@@ -1,0 +1,13 @@
+//
+//  MockObjects.swift
+//  YAPITests
+//
+//  Created by Daniel Seitz on 12/2/17.
+//  Copyright © 2017 Daniel Seitz. All rights reserved.
+//
+
+import Foundation
+
+enum Mock {
+  static let url = URL(string: "https://google.com")!
+}

--- a/YAPI/YAPITests/Mocks/MockObjects.swift
+++ b/YAPI/YAPITests/Mocks/MockObjects.swift
@@ -7,7 +7,16 @@
 //
 
 import Foundation
+import YAPI
+
+// TODO: Make this private and fix any unit tests it breaks
+struct MockError: APIError {
+  var description: String {
+    return "A Mock Error"
+  }
+}
 
 enum Mock {
-  static let url = URL(string: "https://google.com")!
+  static let url: URL = URL(string: "https://google.com")!
+  static let error: APIError = MockError()
 }

--- a/YAPI/YAPITests/NetworkMockObjects.swift
+++ b/YAPI/YAPITests/NetworkMockObjects.swift
@@ -9,12 +9,6 @@
 import Foundation
 @testable import YAPI
 
-struct MockError: APIError {
-  var description: String {
-    return "A Mock Error"
-  }
-}
-
 class MockURLSession: URLSessionProtocol {
   var nextData: Data?
   var nextError: Error?

--- a/YAPI/YAPITests/TestHelpers/YAPIXCNetworkTestCase.swift
+++ b/YAPI/YAPITests/TestHelpers/YAPIXCNetworkTestCase.swift
@@ -1,0 +1,23 @@
+//
+//  YAPIXCNetworkTestCase.swift
+//  YAPITests
+//
+//  Created by Daniel Seitz on 12/2/17.
+//  Copyright © 2017 Daniel Seitz. All rights reserved.
+//
+
+import Foundation
+@testable import YAPI
+
+class YAPIXCNetworkTestCase: YAPIXCTestCase {
+  lazy var session: HTTPClient = {
+    return HTTPClient(session: mockSession)
+  }()
+  private(set) var mockSession = MockURLSession()
+  
+  override func tearDown() {
+    mockSession = MockURLSession()
+    
+    super.tearDown()
+  }
+}

--- a/YAPI/YAPITests/YAPIXCTestCase.swift
+++ b/YAPI/YAPITests/YAPIXCTestCase.swift
@@ -21,6 +21,7 @@ class YAPIXCTestCase : XCTestCase {
   override class func tearDown() {
     AuthKeys.clearAuthentication()
     
+    Asserts.shouldAssert = true
     super.tearDown()
   }
   


### PR DESCRIPTION
Previously, if there was an attempted image load while the same image
was already being loaded we would just return an error saying to wait
for the in progress image load to complete. This provides a pretty poor
interface as there's no notification for when the image load completes,
so the client would have to either poll the cached image or set up their
own notification to properly load the image.

This change makes it so instead of returning an error we defer the
running of the completion handler until the in progress load completes.
Once the load completes it signals all other handlers waiting for the
image and runs them.