### PR TITLE
Preload results sooner, add tests for results screen

### DIFF
--- a/YAPI/YAPITests/AssertOverride.swift
+++ b/YAPI/YAPITests/AssertOverride.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-enum Asserts {
-  static var shouldAssert: Bool = true
+public enum Asserts {
+  public static var shouldAssert: Bool = true
 }
 
 // Disable asserts for testing
-func assert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func assert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
   if Asserts.shouldAssert {
     Swift.assert(condition, message, file: file, line: line)
   }
@@ -22,7 +22,7 @@ func assert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> 
   }
 }
 
-func assertionFailure(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func assertionFailure(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
   if Asserts.shouldAssert {
     Swift.assertionFailure(message, file: file, line: line)
   }

--- a/project-alpha/project-alpha.xcodeproj/project.pbxproj
+++ b/project-alpha/project-alpha.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		085870551FC96A43000F973A /* OAuthSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 085870541FC96A43000F973A /* OAuthSwift.framework */; };
 		085870561FC96A43000F973A /* OAuthSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 085870541FC96A43000F973A /* OAuthSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0858705A1FCB5B41000F973A /* ResultActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085870591FCB5B41000F973A /* ResultActionHandler.swift */; };
+		0858D7591FDDE3610057AD3B /* ResultActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858D7581FDDE3610057AD3B /* ResultActionHandlerTests.swift */; };
+		0858D75B1FDDE4090057AD3B /* MockNetworkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0858D75A1FDDE4090057AD3B /* MockNetworkAdapter.swift */; };
 		087648AF1FB8FF190058E110 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648AE1FB8FF190058E110 /* AppDelegate.swift */; };
 		087648B11FB8FF190058E110 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648B01FB8FF190058E110 /* ViewController.swift */; };
 		087648B41FB8FF190058E110 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 087648B21FB8FF190058E110 /* Main.storyboard */; };
@@ -45,6 +47,9 @@
 		08E0F6911FBDAA31004C3D24 /* GooglePlaceAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E0F6901FBDAA31004C3D24 /* GooglePlaceAuthenticator.swift */; };
 		08EAD6851FD531710082DAA6 /* LocationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6841FD531710082DAA6 /* LocationManagerTests.swift */; };
 		08EAD6881FD533A10082DAA6 /* PAXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6871FD533A10082DAA6 /* PAXCTestCase.swift */; };
+		08EAD68F1FDD1F100082DAA6 /* ResultViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD68E1FDD1F0F0082DAA6 /* ResultViewControllerTests.swift */; };
+		08EAD6911FDD20D80082DAA6 /* MockBusinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */; };
+		08EAD6951FDDDDE80082DAA6 /* SwipeDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */; };
 		A3452E701FBEADE900EAF5B0 /* ResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3452E6F1FBEADE900EAF5B0 /* ResultViewController.swift */; };
 		A34B34551FBD4D52005A8C24 /* secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = A34B34541FBD4D52005A8C24 /* secrets.plist */; };
 		A34B34571FBD675E005A8C24 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34B34561FBD675E005A8C24 /* FilterViewController.swift */; };
@@ -106,6 +111,8 @@
 		0858704C1FC96986000F973A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		085870541FC96A43000F973A /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		085870591FCB5B41000F973A /* ResultActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultActionHandler.swift; sourceTree = "<group>"; };
+		0858D7581FDDE3610057AD3B /* ResultActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultActionHandlerTests.swift; sourceTree = "<group>"; };
+		0858D75A1FDDE4090057AD3B /* MockNetworkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkAdapter.swift; sourceTree = "<group>"; };
 		087648AB1FB8FF190058E110 /* project-alpha.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "project-alpha.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		087648AE1FB8FF190058E110 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		087648B01FB8FF190058E110 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -133,6 +140,9 @@
 		08E0F6901FBDAA31004C3D24 /* GooglePlaceAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GooglePlaceAuthenticator.swift; sourceTree = "<group>"; };
 		08EAD6841FD531710082DAA6 /* LocationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerTests.swift; sourceTree = "<group>"; };
 		08EAD6871FD533A10082DAA6 /* PAXCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PAXCTestCase.swift; sourceTree = "<group>"; };
+		08EAD68E1FDD1F0F0082DAA6 /* ResultViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewControllerTests.swift; sourceTree = "<group>"; };
+		08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBusinessModel.swift; sourceTree = "<group>"; };
+		08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeDirection.swift; sourceTree = "<group>"; };
 		A3452E6F1FBEADE900EAF5B0 /* ResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewController.swift; sourceTree = "<group>"; };
 		A34B34541FBD4D52005A8C24 /* secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = secrets.plist; sourceTree = "<group>"; };
 		A34B34561FBD675E005A8C24 /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
@@ -260,6 +270,15 @@
 			path = ResultScreen;
 			sourceTree = "<group>";
 		};
+		0858D7571FDDE3350057AD3B /* ResultScreen */ = {
+			isa = PBXGroup;
+			children = (
+				08EAD68E1FDD1F0F0082DAA6 /* ResultViewControllerTests.swift */,
+				0858D7581FDDE3610057AD3B /* ResultActionHandlerTests.swift */,
+			);
+			path = ResultScreen;
+			sourceTree = "<group>";
+		};
 		087648A21FB8FF190058E110 = {
 			isa = PBXGroup;
 			children = (
@@ -288,6 +307,7 @@
 		087648AD1FB8FF190058E110 /* project-alpha */ = {
 			isa = PBXGroup;
 			children = (
+				08EAD6931FDDDDD90082DAA6 /* Enums */,
 				08D74CDE1FD4FE1E00306586 /* Utilities */,
 				085870571FCB5B16000F973A /* Controllers */,
 				085870471FC57912000F973A /* Models */,
@@ -359,6 +379,7 @@
 		08D74CE31FD51ADC00306586 /* IntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				0858D7571FDDE3350057AD3B /* ResultScreen */,
 				08D74CE61FD51B4100306586 /* Utilities */,
 				08D74CE41FD51AEE00306586 /* MapViewControllerTests.swift */,
 			);
@@ -378,6 +399,8 @@
 			children = (
 				08D74CEE1FD528FF00306586 /* Mock.swift */,
 				08D74CF01FD5295800306586 /* MockLocationManager.swift */,
+				08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */,
+				0858D75A1FDDE4090057AD3B /* MockNetworkAdapter.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -396,6 +419,14 @@
 				08EAD6871FD533A10082DAA6 /* PAXCTestCase.swift */,
 			);
 			path = TestHelpers;
+			sourceTree = "<group>";
+		};
+		08EAD6931FDDDDD90082DAA6 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */,
+			);
+			path = Enums;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -553,6 +584,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08EAD6951FDDDDE80082DAA6 /* SwipeDirection.swift in Sources */,
 				0858702E1FC3E9C0000F973A /* UIView+project-alpha.swift in Sources */,
 				A34B34571FBD675E005A8C24 /* FilterViewController.swift in Sources */,
 				0846EBA41FBC156E001B0F69 /* NetworkAdapter.swift in Sources */,
@@ -583,12 +615,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08EAD6911FDD20D80082DAA6 /* MockBusinessModel.swift in Sources */,
 				08EAD6851FD531710082DAA6 /* LocationManagerTests.swift in Sources */,
 				08D74CF11FD5295800306586 /* MockLocationManager.swift in Sources */,
+				0858D7591FDDE3610057AD3B /* ResultActionHandlerTests.swift in Sources */,
 				087648C41FB8FF190058E110 /* project_alphaTests.swift in Sources */,
+				08EAD68F1FDD1F100082DAA6 /* ResultViewControllerTests.swift in Sources */,
 				08D74CE51FD51AEE00306586 /* MapViewControllerTests.swift in Sources */,
 				08EAD6881FD533A10082DAA6 /* PAXCTestCase.swift in Sources */,
 				08D74CE81FD51B5A00306586 /* ViewControllerIntegrationTestCase.swift in Sources */,
+				0858D75B1FDDE4090057AD3B /* MockNetworkAdapter.swift in Sources */,
 				08D74CEF1FD528FF00306586 /* Mock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/project-alpha/project-alpha.xcodeproj/project.pbxproj
+++ b/project-alpha/project-alpha.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		08EAD68F1FDD1F100082DAA6 /* ResultViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD68E1FDD1F0F0082DAA6 /* ResultViewControllerTests.swift */; };
 		08EAD6911FDD20D80082DAA6 /* MockBusinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */; };
 		08EAD6951FDDDDE80082DAA6 /* SwipeDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */; };
+		08FEB65C1FE437CB00E43632 /* MockResultViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FEB65B1FE437CB00E43632 /* MockResultViewControllerDelegate.swift */; };
+		08FEB65E1FE43A0800E43632 /* MockResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FEB65D1FE43A0800E43632 /* MockResultViewController.swift */; };
+		08FEB6601FE5010600E43632 /* Assertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FEB65F1FE5010600E43632 /* Assertion.swift */; };
 		A3452E701FBEADE900EAF5B0 /* ResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3452E6F1FBEADE900EAF5B0 /* ResultViewController.swift */; };
 		A34B34551FBD4D52005A8C24 /* secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = A34B34541FBD4D52005A8C24 /* secrets.plist */; };
 		A34B34571FBD675E005A8C24 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34B34561FBD675E005A8C24 /* FilterViewController.swift */; };
@@ -143,6 +146,9 @@
 		08EAD68E1FDD1F0F0082DAA6 /* ResultViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewControllerTests.swift; sourceTree = "<group>"; };
 		08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBusinessModel.swift; sourceTree = "<group>"; };
 		08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeDirection.swift; sourceTree = "<group>"; };
+		08FEB65B1FE437CB00E43632 /* MockResultViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResultViewControllerDelegate.swift; sourceTree = "<group>"; };
+		08FEB65D1FE43A0800E43632 /* MockResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResultViewController.swift; sourceTree = "<group>"; };
+		08FEB65F1FE5010600E43632 /* Assertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assertion.swift; sourceTree = "<group>"; };
 		A3452E6F1FBEADE900EAF5B0 /* ResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewController.swift; sourceTree = "<group>"; };
 		A34B34541FBD4D52005A8C24 /* secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = secrets.plist; sourceTree = "<group>"; };
 		A34B34561FBD675E005A8C24 /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
@@ -372,6 +378,7 @@
 			children = (
 				08D74CDF1FD4FE2F00306586 /* LocationManager.swift */,
 				08D74CE11FD5005D00306586 /* Weak.swift */,
+				08FEB65F1FE5010600E43632 /* Assertion.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -397,6 +404,7 @@
 		08D74CED1FD528F000306586 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				08FEB65A1FE437A900E43632 /* ResultScreen */,
 				08D74CEE1FD528FF00306586 /* Mock.swift */,
 				08D74CF01FD5295800306586 /* MockLocationManager.swift */,
 				08EAD6901FDD20D80082DAA6 /* MockBusinessModel.swift */,
@@ -427,6 +435,15 @@
 				08EAD6941FDDDDE80082DAA6 /* SwipeDirection.swift */,
 			);
 			path = Enums;
+			sourceTree = "<group>";
+		};
+		08FEB65A1FE437A900E43632 /* ResultScreen */ = {
+			isa = PBXGroup;
+			children = (
+				08FEB65B1FE437CB00E43632 /* MockResultViewControllerDelegate.swift */,
+				08FEB65D1FE43A0800E43632 /* MockResultViewController.swift */,
+			);
+			path = ResultScreen;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -597,6 +614,7 @@
 				0858705A1FCB5B41000F973A /* ResultActionHandler.swift in Sources */,
 				A3452E701FBEADE900EAF5B0 /* ResultViewController.swift in Sources */,
 				08E0F6911FBDAA31004C3D24 /* GooglePlaceAuthenticator.swift in Sources */,
+				08FEB6601FE5010600E43632 /* Assertion.swift in Sources */,
 				08E0F68D1FBDA550004C3D24 /* YelpV2NetworkAdapter.swift in Sources */,
 				0858703B1FC3F19C000F973A /* NSLayoutConstraint+PureLayout.m in Sources */,
 				0846EBA71FBC1CE1001B0F69 /* Authenticator.swift in Sources */,
@@ -615,6 +633,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08FEB65C1FE437CB00E43632 /* MockResultViewControllerDelegate.swift in Sources */,
 				08EAD6911FDD20D80082DAA6 /* MockBusinessModel.swift in Sources */,
 				08EAD6851FD531710082DAA6 /* LocationManagerTests.swift in Sources */,
 				08D74CF11FD5295800306586 /* MockLocationManager.swift in Sources */,
@@ -623,6 +642,7 @@
 				08EAD68F1FDD1F100082DAA6 /* ResultViewControllerTests.swift in Sources */,
 				08D74CE51FD51AEE00306586 /* MapViewControllerTests.swift in Sources */,
 				08EAD6881FD533A10082DAA6 /* PAXCTestCase.swift in Sources */,
+				08FEB65E1FE43A0800E43632 /* MockResultViewController.swift in Sources */,
 				08D74CE81FD51B5A00306586 /* ViewControllerIntegrationTestCase.swift in Sources */,
 				0858D75B1FDDE4090057AD3B /* MockNetworkAdapter.swift in Sources */,
 				08D74CEF1FD528FF00306586 /* Mock.swift in Sources */,

--- a/project-alpha/project-alpha/Controllers/ResultScreen/ResultActionHandler.swift
+++ b/project-alpha/project-alpha/Controllers/ResultScreen/ResultActionHandler.swift
@@ -9,34 +9,48 @@
 import UIKit
 import YAPI
 
-protocol ResultViewControllerOperations {
+protocol ResultViewControllerDelegate {
   func retrieveBusinesses(with params: SearchParameters,
                           completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void)
-  func selectOption()
-  func discardOption()
+  func selectOption(_ businessModel: BusinessModel?)
+  func discardOption(_ businessModel: BusinessModel?)
 }
 
-class ResultActionHandler: ResultViewControllerOperations {
-  // FIXME: I think there's a reference cycle here, investigate
-  let viewController: ResultViewController
-  
+class ResultActionHandler: ResultViewControllerDelegate {
   let networkAdapter: NetworkAdapter
   
-  init(viewController: ResultViewController, networkAdapter: NetworkAdapter) {
-    self.viewController = viewController
+  private var searchInProgress: Bool
+  
+  init(networkAdapter: NetworkAdapter) {
     self.networkAdapter = networkAdapter
+    self.searchInProgress = false
   }
   
   func retrieveBusinesses(with params: SearchParameters,
                           completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void) {
-    networkAdapter.makeSearchRequest(with: params, completionHandler: completionHandler)
+    // So we don't have to worry about non-atomic operations when setting the searchInProgress flag
+    assert(Thread.isMainThread, "Only request new businesses from the main thread")
+
+    guard !searchInProgress else { return }
+
+    log(.info, for: .general, message: "Loading next batch of businesses")
+
+    searchInProgress = true
+    networkAdapter.makeSearchRequest(with: params) { [weak self] result in
+      self?.searchInProgress = false
+      completionHandler(result)
+    }
   }
   
-  func selectOption() {
-    print("Selected")
+  func selectOption(_ businessModel: BusinessModel?) {
+    guard let businessModel = businessModel else { return }
+
+    print("Selected \(businessModel.name)")
   }
   
-  func discardOption() {
-    print("Discarded")
+  func discardOption(_ businessModel: BusinessModel?) {
+    guard let businessModel = businessModel else { return }
+
+    print("Discarded \(businessModel.name)")
   }
 }

--- a/project-alpha/project-alpha/Controllers/ResultScreen/ResultActionHandler.swift
+++ b/project-alpha/project-alpha/Controllers/ResultScreen/ResultActionHandler.swift
@@ -9,7 +9,9 @@
 import UIKit
 import YAPI
 
-protocol ResultViewControllerDelegate {
+protocol ResultViewControllerDelegate: class {
+  var viewController: ResultViewController? { get set }
+  
   func retrieveBusinesses(with params: SearchParameters,
                           completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void)
   func selectOption(_ businessModel: BusinessModel?)
@@ -18,6 +20,20 @@ protocol ResultViewControllerDelegate {
 
 class ResultActionHandler: ResultViewControllerDelegate {
   let networkAdapter: NetworkAdapter
+  private weak var _viewController: ResultViewController?
+  
+  var viewController: ResultViewController? {
+    get {
+      return _viewController
+    }
+    set {
+      guard _viewController == nil else {
+        assertionFailure("Attempted to bind action handler to more than one view controller")
+        return
+      }
+      _viewController = newValue
+    }
+  }
   
   private var searchInProgress: Bool
   
@@ -43,12 +59,18 @@ class ResultActionHandler: ResultViewControllerDelegate {
   }
   
   func selectOption(_ businessModel: BusinessModel?) {
+    defer {
+      viewController?.showNextOption()
+    }
     guard let businessModel = businessModel else { return }
 
     print("Selected \(businessModel.name)")
   }
   
   func discardOption(_ businessModel: BusinessModel?) {
+    defer {
+      viewController?.showNextOption()
+    }
     guard let businessModel = businessModel else { return }
 
     print("Discarded \(businessModel.name)")

--- a/project-alpha/project-alpha/Controllers/ResultScreen/ResultViewController.swift
+++ b/project-alpha/project-alpha/Controllers/ResultScreen/ResultViewController.swift
@@ -56,6 +56,8 @@ class ResultViewController: UIViewController {
     
     super.init(nibName: nil, bundle: nil)
     
+    self.delegate.viewController = self
+    
     self.setup(card: backupCard, withGestureRecognizer: false)
     self.setup(card: card, withGestureRecognizer: true)
 
@@ -193,7 +195,6 @@ extension ResultViewController {
       case .right:
         self.delegate.selectOption(self.cardViewModel.businessModel)
       }
-      self.showNextOption()
     }
     
     if animated {

--- a/project-alpha/project-alpha/Controllers/ResultScreen/ResultViewController.swift
+++ b/project-alpha/project-alpha/Controllers/ResultScreen/ResultViewController.swift
@@ -10,11 +10,23 @@ import UIKit
 import MapKit
 import YAPI
 
-class ResultViewController: UIViewController {
-  lazy private var actionHandler: ResultViewControllerOperations = {
-    return ResultActionHandler(viewController: self, networkAdapter: self.networkAdapter)
-  }()
+struct ResultViewControllerPageModel {
+  let delegate: ResultViewControllerDelegate
+  let searchParameters: SearchParameters
 
+  /// Minimum number of businesses loaded before preloading another batch of businesses
+  let refreshThreshold: UInt
+  
+  init(delegate: ResultViewControllerDelegate,
+       searchParameters: SearchParameters,
+       refreshThreshold: UInt = 5) {
+    self.delegate = delegate
+    self.searchParameters = searchParameters
+    self.refreshThreshold = refreshThreshold
+  }
+}
+
+class ResultViewController: UIViewController {
   lazy private var cardViewModel: ResultCardViewModel = {
     return ResultCardViewModel(updateBlock: { [weak self] businessModel in
       self?.card.display(businessModel: businessModel)
@@ -27,15 +39,18 @@ class ResultViewController: UIViewController {
     })
   }()
 
-  private var card: UIView & ResultDisplayable
-  private var backupCard: UIView & ResultDisplayable
-  private var businesses: [BusinessModel] = []
-  private let networkAdapter: NetworkAdapter
+  private(set) var businesses: [BusinessModel] = []
+
+  private let card: UIView & ResultDisplayable
+  private let backupCard: UIView & ResultDisplayable
+  private let delegate: ResultViewControllerDelegate
   private let searchParameters: SearchParameters
+  private let refreshThreshold: UInt
   
-  init(networkAdapter: NetworkAdapter, searchParameters: SearchParameters) {
-    self.networkAdapter = networkAdapter
-    self.searchParameters = searchParameters
+  init(pageModel: ResultViewControllerPageModel) {
+    self.delegate = pageModel.delegate
+    self.searchParameters = pageModel.searchParameters
+    self.refreshThreshold = pageModel.refreshThreshold
     self.card = ResultCardView()
     self.backupCard = ResultCardView()
     
@@ -44,7 +59,7 @@ class ResultViewController: UIViewController {
     self.setup(card: backupCard, withGestureRecognizer: false)
     self.setup(card: card, withGestureRecognizer: true)
 
-    actionHandler.retrieveBusinesses(with: searchParameters) { result in
+    delegate.retrieveBusinesses(with: searchParameters) { result in
       guard case .ok(let businesses) = result else {
         log(.error, for: .network, message: "Error retrieving business results: \(result.unwrapErr())")
         return
@@ -67,10 +82,6 @@ class ResultViewController: UIViewController {
   
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
   }
   
   private func setup(card: UIView, withGestureRecognizer: Bool) {
@@ -163,53 +174,65 @@ extension ResultViewController {
     
     // Center point is within the leftmost quadrant of the screen
     if card.center.x < quarterWidth {
-      UIView.animate(withDuration: 0.3, animations: {
-        card.center = CGPoint(x: card.center.x - 200, y: card.center.y + 75)
-        card.alpha = 0.0
-      }, completion: { (success) in
-        self.showNextOption()
-        self.actionHandler.discardOption()
-      })
+      swipe(.left, animated: true)
     }
-      // Center point is within the rightmost quadrant of the screen
+    // Center point is within the rightmost quadrant of the screen
     else if card.center.x > (view.frame.width - quarterWidth) {
-      UIView.animate(withDuration: 0.3, animations: {
-        card.center = CGPoint(x: card.center.x + 200, y: card.center.y + 75)
-        card.alpha = 0.0
-      }, completion: { (success) in
-        self.showNextOption()
-        self.actionHandler.selectOption()
-      })
+      swipe(.right, animated: true)
     }
     else {
       resetCard(animated: true)
     }
   }
   
-  private func showNextOption() {
-    if businesses.count > 1 {
-      cardViewModel.businessModel = businesses.popFirst()
-      backupCardViewModel.businessModel = businesses.first
-      
-      resetCard(animated: false)
+  func swipe(_ direction: SwipeDirection, animated: Bool) {
+    let completionBlock: (Bool) -> Void = { success in
+      switch direction {
+      case .left:
+        self.delegate.discardOption(self.cardViewModel.businessModel)
+      case .right:
+        self.delegate.selectOption(self.cardViewModel.businessModel)
+      }
+      self.showNextOption()
     }
-      // TESTING: Get the next chunk of restauraunts, offset is handled in YelpV3NetworkAdapter as a hardcoded value, we will need to go back and make it more generic for it to work
+    
+    if animated {
+      let offset: CGFloat = direction.isLeft ? -200 : 200
+      UIView.animate(withDuration: 0.3, animations: {
+        self.card.center = CGPoint(x: self.card.center.x + offset, y: self.card.center.y + 75)
+        self.card.alpha = 0.0
+      }, completion: completionBlock)
+    }
     else {
-      actionHandler.retrieveBusinesses(with: searchParameters) { [weak self] result in
-        
+      completionBlock(true)
+    }
+  }
+  
+  func showNextOption() {
+    let displayOption = { [weak self] in
+      self?.cardViewModel.businessModel = self?.businesses.popFirst()
+      self?.backupCardViewModel.businessModel = self?.businesses.first
+      
+      self?.resetCard(animated: false)
+    }
+
+    if businesses.count < refreshThreshold {
+      // Get the next block of restauraunts
+      delegate.retrieveBusinesses(with: searchParameters) { [weak self] result in
         guard case .ok(let businesses) = result else {
           print("Error: \(result.unwrapErr())")
           return
         }
         
-        self?.businesses.append(contentsOf: businesses)
+        self?.businesses.append(contentsOf: businesses.shuffled())
         
-        DispatchQueue.main.async {
-          self?.cardViewModel.businessModel = self?.businesses.popFirst()
-          self?.backupCardViewModel.businessModel = self?.businesses.first
-          self?.resetCard(animated: false)
+        if self?.cardViewModel.businessModel == nil {
+          DispatchQueue.main.async {
+            displayOption()
+          }
         }
       }
     }
+    displayOption()
   }
 }

--- a/project-alpha/project-alpha/Enums/SwipeDirection.swift
+++ b/project-alpha/project-alpha/Enums/SwipeDirection.swift
@@ -1,0 +1,24 @@
+//
+//  SwipeDirection.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 12/10/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+
+enum SwipeDirection {
+  case left
+  case right
+}
+
+extension SwipeDirection {
+  var isLeft: Bool {
+    return self == .left
+  }
+  
+  var isRight: Bool {
+    return self == .right
+  }
+}

--- a/project-alpha/project-alpha/FilterViewController.swift
+++ b/project-alpha/project-alpha/FilterViewController.swift
@@ -105,8 +105,10 @@ class FilterViewController: UIViewController, UIPickerViewDelegate, UIPickerView
 
         DispatchQueue.main.async {
           let params = SearchParameters(distance: (Int(self.distanceLabel.text ?? "") ?? 10) * 100)
+          let pageModel = ResultViewControllerPageModel(delegate: ResultActionHandler(networkAdapter: networkAdapter),
+                                                        searchParameters: params)
 
-          let resultVC = ResultViewController(networkAdapter: networkAdapter, searchParameters: params)
+          let resultVC = ResultViewController(pageModel: pageModel)
           self.navigationController?.pushViewController(resultVC, animated: true)
           self.stopIndicator()
         }

--- a/project-alpha/project-alpha/Models/BusinessModel.swift
+++ b/project-alpha/project-alpha/Models/BusinessModel.swift
@@ -14,27 +14,3 @@ protocol BusinessModel {
   var name: String { get }
   var imageReference: ImageReference? { get }
 }
-
-struct MockBusiness: BusinessModel {
-  private final class MockImageReference: ImageReference {
-    let _image: UIImage
-    
-    override var cachedImage: UIImage? {
-      return _image
-    }
-    
-    init(image: UIImage) {
-      self._image = image
-      super.init(from: URL(string: "https://google.com")!)
-    }
-  }
-  
-  let name: String
-  let imageReference: ImageReference?
-  let id: String = "id"
-  
-  init(name: String, image: UIImage) {
-    self.name = name
-    self.imageReference = MockImageReference(image: image)
-  }
-}

--- a/project-alpha/project-alpha/Utilities/Assertion.swift
+++ b/project-alpha/project-alpha/Utilities/Assertion.swift
@@ -1,0 +1,19 @@
+//
+//  Assertion.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 12/15/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+
+import YAPI
+
+public func assert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  YAPI.assert(condition, message, file: file, line: line)
+}
+
+public func assertionFailure(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+  YAPI.assertionFailure(message, file: file, line: line)
+}

--- a/project-alpha/project-alpha/Views/ResultCardView.swift
+++ b/project-alpha/project-alpha/Views/ResultCardView.swift
@@ -22,11 +22,6 @@ class ResultCardViewModel {
   }
 }
 
-enum SwipeDirection {
-  case left
-  case right
-}
-
 protocol ResultDisplayable {
   func display(businessModel: BusinessModel?)
   func startChoosing(direction: SwipeDirection)

--- a/project-alpha/project-alphaTests/IntegrationTests/MapViewControllerTests.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/MapViewControllerTests.swift
@@ -13,7 +13,7 @@ import CoreLocation
 @testable import project_alpha
 
 class MapViewControllerTests: ViewControllerIntegrationTestCase {
-  private var mockLocationManager: MockLocationManager = Mock.locationManager
+  private var mockLocationManager: Mock.LocationManager = Mock.locationManager
 
   override func setUp() {
     mockLocationManager = Mock.locationManager

--- a/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultActionHandlerTests.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultActionHandlerTests.swift
@@ -1,0 +1,65 @@
+//
+//  ResultActionHandlerTests.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/10/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import project_alpha
+
+class ResultActionHandlerTests: PAXCTestCase {
+  var actionHandler: ResultActionHandler!
+  var mockNetworkAdapter: Mock.NetworkAdapter!
+
+  override func setUp() {
+    super.setUp()
+
+    mockNetworkAdapter = Mock.networkAdapter
+    actionHandler = ResultActionHandler(networkAdapter: mockNetworkAdapter)
+  }
+  
+  func test_ResultActionHandler_RetrieveBusinessesMakesNetworkRequest() {
+    let params = SearchParameters(distance: 10)
+
+    XCTAssertFalse(mockNetworkAdapter.madeSearchRequest)
+
+    actionHandler.retrieveBusinesses(with: params) { result in /* Mock Handler */ }
+    
+    XCTAssertTrue(mockNetworkAdapter.madeSearchRequest)
+  }
+  
+  func test_ResultActionHandler_OnlyOneRetrieveBusinessesCallCanBeMadeAtOnce() {
+    let params = SearchParameters(distance: 10)
+    let expect = expectation(description: "First network call finished")
+    mockNetworkAdapter.asyncAfter = .milliseconds(100)
+    
+    actionHandler.retrieveBusinesses(with: params) { result in
+      expect.fulfill()
+    }
+    
+    actionHandler.retrieveBusinesses(with: params) { result in
+      XCTFail("Second network request should not be made")
+    }
+    
+    actionHandler.retrieveBusinesses(with: params) { result in
+      XCTFail("Third network request should not be made")
+    }
+    
+    waitForExpectations(timeout: 1.0)
+  }
+  
+  func test_ResultActionHandler_SelectOption() {
+    // Test stub for when this is actually implemented
+    
+    actionHandler.selectOption(Mock.businessModel)
+  }
+  
+  func test_ResultActionHandler_DiscardOption() {
+    // Test stub for when this is actually implemented
+    
+    actionHandler.discardOption(Mock.businessModel)
+  }
+}

--- a/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultActionHandlerTests.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultActionHandlerTests.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import XCTest
+import YAPI
 @testable import project_alpha
 
 class ResultActionHandlerTests: PAXCTestCase {
@@ -19,6 +20,21 @@ class ResultActionHandlerTests: PAXCTestCase {
 
     mockNetworkAdapter = Mock.networkAdapter
     actionHandler = ResultActionHandler(networkAdapter: mockNetworkAdapter)
+  }
+  
+  func test_ResultActionHandler_OnlySetsViewControllerOnce() {
+    let vc1 = Mock.ResultScreen.viewController
+    let vc2 = Mock.ResultScreen.viewController
+    
+    XCTAssertNil(actionHandler.viewController)
+    
+    actionHandler.viewController = vc1
+    
+    XCTAssertEqual(actionHandler.viewController, vc1)
+    
+    actionHandler.viewController = vc2
+    
+    XCTAssertEqual(actionHandler.viewController, vc1)
   }
   
   func test_ResultActionHandler_RetrieveBusinessesMakesNetworkRequest() {

--- a/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultViewControllerTests.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultViewControllerTests.swift
@@ -1,0 +1,92 @@
+//
+//  ResultViewControllerTests.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/9/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+import XCTest
+@testable import project_alpha
+
+private class MockDelegate: ResultViewControllerDelegate {
+  private(set) var selected: Bool = false
+  private(set) var discarded: Bool = false
+  private(set) var retrieved: Bool = false
+    
+  var nextResult: Result<[BusinessModel], APIError> = .ok(Array(repeating: Mock.businessModel, count: 10))
+
+  func retrieveBusinesses(with params: SearchParameters,
+                          completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void) {
+    retrieved = true
+    completionHandler(nextResult)
+  }
+  
+  func selectOption(_ businessModel: BusinessModel?) {
+    selected = true
+  }
+  
+  func discardOption(_ businessModel: BusinessModel?) {
+    discarded = true
+  }
+}
+
+class ResultViewControllerTests: ViewControllerIntegrationTestCase {
+  let mockSearchParameters = SearchParameters(distance: 100)
+  private var mockDelegate: MockDelegate = MockDelegate()
+  
+  var resultViewController: ResultViewController {
+    return viewController as! ResultViewController
+  }
+  
+  override func setUp() {
+    mockDelegate = MockDelegate()
+    let pageModel = ResultViewControllerPageModel(delegate: mockDelegate,
+                                                  searchParameters: mockSearchParameters)
+    viewController = ResultViewController(pageModel: pageModel)
+    
+    super.setUp()
+  }
+  
+  func test_ResultViewController_RetrievesBusinessesOnInitialization() {
+    XCTAssertTrue(mockDelegate.retrieved)
+    XCTAssertEqual(resultViewController.businesses.count, 9)
+  }
+  
+  func test_ResultViewController_ShowNextOption_RemovesFromBusinessArray() {
+    XCTAssertEqual(resultViewController.businesses.count, 9)
+    
+    resultViewController.showNextOption()
+    
+    XCTAssertEqual(resultViewController.businesses.count, 8)
+  }
+  
+  func test_ResultViewController_BusinessesBelowThresholdFetchesNewBusinesses() {
+    let pageModel = ResultViewControllerPageModel(delegate: mockDelegate, searchParameters: mockSearchParameters, refreshThreshold: 10)
+    viewController = ResultViewController(pageModel: pageModel)
+    
+    XCTAssertEqual(resultViewController.businesses.count, 9)
+    
+    resultViewController.showNextOption()
+    
+    XCTAssertEqual(resultViewController.businesses.count, 18)
+  }
+  
+  func test_ResultViewController_SwipeRightCallsDelegateSelectionMethod() {
+    XCTAssertFalse(mockDelegate.selected)
+
+    resultViewController.swipe(.right, animated: false)
+    
+    XCTAssertTrue(self.mockDelegate.selected)
+  }
+  
+  func test_ResultViewController_SwipeLeftCallsDelegateDiscardMethod() {
+    XCTAssertFalse(mockDelegate.discarded)
+    
+    resultViewController.swipe(.left, animated: false)
+    
+    XCTAssertTrue(self.mockDelegate.discarded)
+  }
+}

--- a/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultViewControllerTests.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/ResultScreen/ResultViewControllerTests.swift
@@ -11,43 +11,25 @@ import YAPI
 import XCTest
 @testable import project_alpha
 
-private class MockDelegate: ResultViewControllerDelegate {
-  private(set) var selected: Bool = false
-  private(set) var discarded: Bool = false
-  private(set) var retrieved: Bool = false
-    
-  var nextResult: Result<[BusinessModel], APIError> = .ok(Array(repeating: Mock.businessModel, count: 10))
-
-  func retrieveBusinesses(with params: SearchParameters,
-                          completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void) {
-    retrieved = true
-    completionHandler(nextResult)
-  }
-  
-  func selectOption(_ businessModel: BusinessModel?) {
-    selected = true
-  }
-  
-  func discardOption(_ businessModel: BusinessModel?) {
-    discarded = true
-  }
-}
-
 class ResultViewControllerTests: ViewControllerIntegrationTestCase {
   let mockSearchParameters = SearchParameters(distance: 100)
-  private var mockDelegate: MockDelegate = MockDelegate()
+  private var mockDelegate: Mock.ResultScreen.Delegate = Mock.ResultScreen.delegate
   
   var resultViewController: ResultViewController {
     return viewController as! ResultViewController
   }
   
   override func setUp() {
-    mockDelegate = MockDelegate()
+    mockDelegate = Mock.ResultScreen.delegate
     let pageModel = ResultViewControllerPageModel(delegate: mockDelegate,
                                                   searchParameters: mockSearchParameters)
     viewController = ResultViewController(pageModel: pageModel)
     
     super.setUp()
+  }
+  
+  func test_ResultViewController_SetsDelegateViewControllerAsSelf() {
+    XCTAssertTrue(mockDelegate.viewController === viewController)
   }
   
   func test_ResultViewController_RetrievesBusinessesOnInitialization() {

--- a/project-alpha/project-alphaTests/IntegrationTests/Utilities/ViewControllerIntegrationTestCase.swift
+++ b/project-alpha/project-alphaTests/IntegrationTests/Utilities/ViewControllerIntegrationTestCase.swift
@@ -10,24 +10,38 @@ import Foundation
 import XCTest
 
 class ViewControllerIntegrationTestCase: PAXCTestCase {
-  var viewController: UIViewController!
+  private var _viewController: UIViewController!
+  
+  var viewController: UIViewController {
+    get {
+      return _viewController
+    }
+    set {
+      _viewController = newValue
+      _viewController.viewDidLoad()
+    }
+  }
   
   override func setUp() {
     super.setUp()
-
-    guard let viewController = viewController else {
+    
+    guard _viewController != nil else {
       preconditionFailure("Subclassing test cases must set viewController value before calling setUp")
     }
-
-    viewController.viewDidLoad()
   }
   
-  func makeViewAppear(_ animated: Bool) {
+  override func tearDown() {
+    _viewController = nil
+
+    super.tearDown()
+  }
+  
+  final func makeViewAppear(_ animated: Bool) {
     viewController.viewWillAppear(animated)
     viewController.viewDidAppear(animated)
   }
   
-  func makeViewDisappear(_ animated: Bool) {
+  final func makeViewDisappear(_ animated: Bool) {
     viewController.viewWillDisappear(animated)
     viewController.viewDidDisappear(animated)
   }

--- a/project-alpha/project-alphaTests/Mocks/Mock.swift
+++ b/project-alpha/project-alphaTests/Mocks/Mock.swift
@@ -15,4 +15,7 @@ private struct MockError: Error {}
 
 enum Mock {
   static var error: Error { return MockError() }
+  
+  // MARK: Subnamespaces
+  enum ResultScreen {}
 }

--- a/project-alpha/project-alphaTests/Mocks/MockBusinessModel.swift
+++ b/project-alpha/project-alphaTests/Mocks/MockBusinessModel.swift
@@ -1,0 +1,40 @@
+//
+//  MockBusinessModel.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/9/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+@testable import project_alpha
+
+extension Mock {
+  static var businessModel: BusinessModel { return BusinessModel(name: "Mock", id: "id", image: #imageLiteral(resourceName: "fork-and-knife")) }
+  
+  struct BusinessModel: project_alpha.BusinessModel {
+    private final class MockImageReference: ImageReference {
+      let _image: UIImage
+      
+      override var cachedImage: UIImage? {
+        return _image
+      }
+      
+      init(image: UIImage) {
+        self._image = image
+        super.init(from: URL(string: "https://google.com")!)
+      }
+    }
+    
+    let name: String
+    let id: String
+    let imageReference: ImageReference?
+    
+    init(name: String, id: String, image: UIImage) {
+      self.name = name
+      self.id = id
+      self.imageReference = MockImageReference(image: image)
+    }
+  }
+}

--- a/project-alpha/project-alphaTests/Mocks/MockLocationManager.swift
+++ b/project-alpha/project-alphaTests/Mocks/MockLocationManager.swift
@@ -12,26 +12,26 @@ import CoreLocation
 @testable import project_alpha
 
 extension Mock {
-  static var locationManager: MockLocationManager { return MockLocationManager() }
-}
+  static var locationManager: LocationManager { return LocationManager() }
 
-class MockLocationManager {
-  private(set) var didRequestAuthorization: Bool = false
-  private(set) var didStartUpdatingLocation: Bool = false
-  private(set) var observers: [CLLocationManagerDelegate] = []
-  
-  // LocationManagerProtocol conformance
-  var desiredAccuracy: CLLocationAccuracy = Double.nan // An invalid value for testing purposes
-  var shouldDisplayHeadingCalibration: Bool = false
-  
-  fileprivate init() {}
-
-  func contains(observer: NSObject) -> Bool {
-    return observers.contains { $0.isEqual(observer) }
+  class LocationManager {
+    private(set) var didRequestAuthorization: Bool = false
+    private(set) var didStartUpdatingLocation: Bool = false
+    private(set) var observers: [CLLocationManagerDelegate] = []
+    
+    // LocationManagerProtocol conformance
+    var desiredAccuracy: CLLocationAccuracy = Double.nan // An invalid value for testing purposes
+    var shouldDisplayHeadingCalibration: Bool = false
+    
+    fileprivate init() {}
+    
+    func contains(observer: NSObject) -> Bool {
+      return observers.contains { $0.isEqual(observer) }
+    }
   }
 }
 
-extension MockLocationManager: LocationManagerProtocol {
+extension Mock.LocationManager: LocationManagerProtocol {
   func requestWhenInUseAuthorization() {
     didRequestAuthorization = true
   }

--- a/project-alpha/project-alphaTests/Mocks/MockNetworkAdapter.swift
+++ b/project-alpha/project-alphaTests/Mocks/MockNetworkAdapter.swift
@@ -1,0 +1,37 @@
+//
+//  MockNetworkAdapter.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/10/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+
+@testable import project_alpha
+
+extension Mock {
+  static var networkAdapter: NetworkAdapter { return NetworkAdapter() }
+  
+  class NetworkAdapter: project_alpha.NetworkAdapter {
+    private(set) var madeSearchRequest: Bool = false
+    
+    var nextResult: SearchResult = .ok([])
+    
+    var asyncAfter: DispatchTimeInterval?
+    
+    fileprivate init() {}
+
+    func makeSearchRequest(with params: SearchParameters, completionHandler: @escaping (SearchResult) -> Void) {
+      if let asyncAfter = asyncAfter {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + asyncAfter) {
+          completionHandler(self.nextResult)
+        }
+      }
+      else {
+        completionHandler(nextResult)
+      }
+      madeSearchRequest = true
+    }
+  }
+}

--- a/project-alpha/project-alphaTests/Mocks/ResultScreen/MockResultViewController.swift
+++ b/project-alpha/project-alphaTests/Mocks/ResultScreen/MockResultViewController.swift
@@ -1,0 +1,22 @@
+//
+//  MockResultViewController.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/15/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+@testable import project_alpha
+
+extension Mock.ResultScreen {
+  static var viewController: ResultViewController { return ViewController() }
+  
+  private class ViewController: ResultViewController {
+    fileprivate convenience init() {
+      let pageModel = ResultViewControllerPageModel(delegate: Mock.ResultScreen.delegate, searchParameters: SearchParameters(distance: 10))
+      
+      self.init(pageModel: pageModel)
+    }
+  }
+}

--- a/project-alpha/project-alphaTests/Mocks/ResultScreen/MockResultViewControllerDelegate.swift
+++ b/project-alpha/project-alphaTests/Mocks/ResultScreen/MockResultViewControllerDelegate.swift
@@ -1,0 +1,43 @@
+//
+//  MockResultViewControllerDelegate.swift
+//  project-alphaTests
+//
+//  Created by Daniel Seitz on 12/15/17.
+//  Copyright © 2017 freebird. All rights reserved.
+//
+
+import Foundation
+import YAPI
+@testable import project_alpha
+
+extension Mock.ResultScreen {
+  static var delegate: Delegate { return Delegate() }
+
+  class Delegate: ResultViewControllerDelegate {
+    
+    var viewController: ResultViewController?
+    
+    private(set) var selected: Bool = false
+    private(set) var discarded: Bool = false
+    private(set) var retrieved: Bool = false
+    
+    var nextResult: Result<[BusinessModel], APIError> = .ok(Array(repeating: Mock.businessModel, count: 10))
+    
+    fileprivate init() {}
+    
+    func retrieveBusinesses(with params: SearchParameters, completionHandler: @escaping (Result<[BusinessModel], APIError>) -> Void) {
+      retrieved = true
+      completionHandler(nextResult)
+    }
+    
+    func selectOption(_ businessModel: BusinessModel?) {
+      selected = true
+    }
+    
+    func discardOption(_ businessModel: BusinessModel?) {
+      discarded = true
+    }
+    
+  }
+}
+

--- a/project-alpha/project-alphaTests/TestHelpers/PAXCTestCase.swift
+++ b/project-alpha/project-alphaTests/TestHelpers/PAXCTestCase.swift
@@ -7,7 +7,20 @@
 //
 
 import Foundation
+import YAPI
 import XCTest
 
 // project-alpha test case override point
-class PAXCTestCase: XCTestCase {}
+class PAXCTestCase: XCTestCase {
+  override func setUp() {
+    super.setUp()
+
+    YAPI.Asserts.shouldAssert = false
+  }
+  
+  override func tearDown() {
+    YAPI.Asserts.shouldAssert = true
+    
+    super.tearDown()
+  }
+}


### PR DESCRIPTION
Adds a `refreshThreshold` field to specify at what point we should retrieve more results. Also did some restructuring around the results screen to make it a bit more testable.