### PR TITLE
Implement address for map view to provide extra information

### DIFF
--- a/project-alpha/project-alpha.xcodeproj/project.pbxproj
+++ b/project-alpha/project-alpha.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		087648B91FB8FF190058E110 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 087648B71FB8FF190058E110 /* LaunchScreen.storyboard */; };
 		087648C41FB8FF190058E110 /* project_alphaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648C31FB8FF190058E110 /* project_alphaTests.swift */; };
 		087648CF1FB8FF190058E110 /* project_alphaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087648CE1FB8FF190058E110 /* project_alphaUITests.swift */; };
+		08914EE4200DAAF4003AA7DF /* AddressModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08914EE3200DAAF4003AA7DF /* AddressModel.swift */; };
+		08914EE6200DB486003AA7DF /* MKMapItem+project-alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08914EE5200DB486003AA7DF /* MKMapItem+project-alpha.swift */; };
 		08CCBE8F1FB8FF9D007EC96E /* YAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08CCBE901FB8FF9D007EC96E /* YAPI.framework */; };
 		08CCBE941FB96D8D007EC96E /* secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 08CCBE931FB96D8D007EC96E /* secrets.plist */; };
 		08D74CE01FD4FE2F00306586 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D74CDF1FD4FE2F00306586 /* LocationManager.swift */; };
@@ -128,6 +130,8 @@
 		087648CA1FB8FF190058E110 /* project-alphaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "project-alphaUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		087648CE1FB8FF190058E110 /* project_alphaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = project_alphaUITests.swift; sourceTree = "<group>"; };
 		087648D01FB8FF190058E110 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		08914EE3200DAAF4003AA7DF /* AddressModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressModel.swift; sourceTree = "<group>"; };
+		08914EE5200DB486003AA7DF /* MKMapItem+project-alpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapItem+project-alpha.swift"; sourceTree = "<group>"; };
 		08CCBE901FB8FF9D007EC96E /* YAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = YAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		08CCBE931FB96D8D007EC96E /* secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = secrets.plist; sourceTree = "<group>"; };
 		08D74CDF1FD4FE2F00306586 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
@@ -220,6 +224,7 @@
 			children = (
 				0858702D1FC3E9C0000F973A /* UIView+project-alpha.swift */,
 				0858704A1FC96651000F973A /* Collections+project-alpha.swift */,
+				08914EE5200DB486003AA7DF /* MKMapItem+project-alpha.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -253,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				085870481FC5791F000F973A /* BusinessModel.swift */,
+				08914EE3200DAAF4003AA7DF /* AddressModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -602,6 +608,7 @@
 				0858702E1FC3E9C0000F973A /* UIView+project-alpha.swift in Sources */,
 				A34B34571FBD675E005A8C24 /* FilterViewController.swift in Sources */,
 				0846EBA41FBC156E001B0F69 /* NetworkAdapter.swift in Sources */,
+				08914EE4200DAAF4003AA7DF /* AddressModel.swift in Sources */,
 				0846EBAA1FBC1D23001B0F69 /* YelpV3Authenticator.swift in Sources */,
 				0858703D1FC3F19C000F973A /* NSArray+PureLayout.m in Sources */,
 				08D74CE21FD5005D00306586 /* Weak.swift in Sources */,
@@ -621,6 +628,7 @@
 				087648AF1FB8FF190058E110 /* AppDelegate.swift in Sources */,
 				0858703C1FC3F19C000F973A /* ALView+PureLayout.m in Sources */,
 				08E0F68B1FBDA4AA004C3D24 /* YelpV2Authenticator.swift in Sources */,
+				08914EE6200DB486003AA7DF /* MKMapItem+project-alpha.swift in Sources */,
 				085870461FC57146000F973A /* ResultCardView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/project-alpha/project-alpha/Extensions/MKMapItem+project-alpha.swift
+++ b/project-alpha/project-alpha/Extensions/MKMapItem+project-alpha.swift
@@ -1,0 +1,21 @@
+//
+//  MKMapItem+project-alpha.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 1/15/18.
+//  Copyright © 2018 freebird. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+extension MKMapItem {
+  convenience init(businessModel: BusinessModel, placemark: MKPlacemark) {
+    self.init(placemark: placemark)
+    
+    self.name = businessModel.name
+    // TODO: Add phone number and url info
+//    self.phoneNumber = businessModel.phoneNumber
+//    self.url = businessModel.url
+  }
+}

--- a/project-alpha/project-alpha/Models/AddressModel.swift
+++ b/project-alpha/project-alpha/Models/AddressModel.swift
@@ -1,0 +1,50 @@
+//
+//  AddressModel.swift
+//  project-alpha
+//
+//  Created by Daniel Seitz on 1/15/18.
+//  Copyright © 2018 freebird. All rights reserved.
+//
+
+import Foundation
+import Contacts
+
+typealias AddressDictionary = [String: String]
+
+protocol AddressModel {
+  var street: String { get }
+  var city: String { get }
+  var state: String { get }
+  var zipCode: String { get }
+  var countryModel: CountryModel { get }
+}
+
+extension AddressModel {
+  var addressDictionary: AddressDictionary {
+    return [
+      CNPostalAddressStreetKey: street,
+      CNPostalAddressCityKey: city,
+      CNPostalAddressStateKey: state,
+      CNPostalAddressPostalCodeKey: zipCode,
+      CNPostalAddressCountryKey: countryModel.name,
+//      CNPostalAddressISOCountryCodeKey: countryModel.isoCode
+    ]
+  }
+  
+  var postalAddress: CNPostalAddress {
+    let postalAddress = CNMutablePostalAddress()
+    postalAddress.street = street
+    postalAddress.city = city
+    postalAddress.state = state
+    postalAddress.postalCode = zipCode
+    postalAddress.country = countryModel.name
+    postalAddress.isoCountryCode = countryModel.isoCode ?? ""
+    
+    return postalAddress.copy() as! CNPostalAddress
+  }
+}
+
+protocol CountryModel {
+  var name: String { get }
+  var isoCode: String? { get }
+}

--- a/project-alpha/project-alpha/Models/BusinessModel.swift
+++ b/project-alpha/project-alpha/Models/BusinessModel.swift
@@ -15,6 +15,5 @@ protocol BusinessModel {
   var name: String { get }
   var imageReference: ImageReference? { get }
   var coordinate: CLLocationCoordinate2D { get }
-  
-  // var address: AddressModel { get }
+  var address: AddressModel? { get }
 }

--- a/project-alpha/project-alpha/Network/Adapters/GooglePlaceNetworkAdapter.swift
+++ b/project-alpha/project-alpha/Network/Adapters/GooglePlaceNetworkAdapter.swift
@@ -25,6 +25,10 @@ extension GoogleEstablishment: BusinessModel {
     
     return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
   }
+  
+  var address: AddressModel? {
+    return nil
+  }
 }
 
 final class GooglePlaceNetworkAdapter: NetworkAdapter {

--- a/project-alpha/project-alpha/Network/Adapters/YelpV2NetworkAdapter.swift
+++ b/project-alpha/project-alpha/Network/Adapters/YelpV2NetworkAdapter.swift
@@ -22,6 +22,12 @@ extension YelpBusiness: BusinessModel {
     
     return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
   }
+  
+  
+  var address: AddressModel? {
+    // TODO: Implement this, we should have the required information
+    return nil
+  }
 }
 
 final class YelpV2NetworkAdapter: NetworkAdapter {

--- a/project-alpha/project-alpha/Network/Adapters/YelpV3NetworkAdapter.swift
+++ b/project-alpha/project-alpha/Network/Adapters/YelpV3NetworkAdapter.swift
@@ -18,6 +18,25 @@ extension YelpV3Business: BusinessModel {
   var coordinate: CLLocationCoordinate2D {
     return self.coordinates.coordinate
   }
+  
+  var address: AddressModel? {
+    return location
+  }
+}
+
+extension YelpV3Location: AddressModel {
+  var street: String {
+    return address1
+  }
+  
+  var countryModel: CountryModel {
+    return YelpV3CountryModel(name: country, isoCode: nil)
+  }
+}
+
+private struct YelpV3CountryModel: CountryModel {
+  var name: String
+  var isoCode: String? = nil
 }
 
 final class YelpV3NetworkAdapter: NetworkAdapter {


### PR DESCRIPTION
Fills in the extra address information that we get from the service. It turns out there's a `name` property on `MKMapItem` that can be used for the display name so we can store the full address alongside it.